### PR TITLE
⚡ Bolt: Reuse canvas for glyph profiling

### DIFF
--- a/.jules/codecraft.md
+++ b/.jules/codecraft.md
@@ -2,3 +2,8 @@
 **Mode:** 🩺 Medic
 **Learning:** The application's `confirmAction` toggling pattern for destructive UI components correctly appended a `confirm-danger` state, but blindly executed `btn.removeAttribute('aria-label')` when reverting or confirming actions, which permanently erased any initially set `aria-label` attributes on those elements (such as `aria-label="Clear Font 1"`), silently crippling accessibility over time.
 **Action:** When working with UI state toggles that momentarily replace `aria-label` text with instructional prompts (e.g., "Confirm?"), always retrieve and stash the initial attribute in a dataset property like `dataset.originalAria` before modifying it. Restore the attribute explicitly (or properly clear it if falsy) when resolving the temporary state.
+
+## 2025-05-18 - [Canvas Overhead in Glyph Profiling]
+**Mode:** ⚡ Bolt
+**Learning:** During parallel execution with `Promise.all`, reusing a single shared `canvas` for operations like `glyph.render` and `getImageData` is safe because these DOM interactions are entirely synchronous. Therefore, creating a new `canvas` instance per glyph inside `getGlyphProfile` was an unnecessary source of DOM allocation and garbage collection overhead.
+**Action:** Share a single offscreen canvas (e.g., `glyphCanvas`) and reuse it across multiple synchronous render-to-buffer calls, using `ctx.save()` and `ctx.restore()` to reset any translations before the next use.

--- a/OpenDensityTool.html
+++ b/OpenDensityTool.html
@@ -718,6 +718,7 @@ self.onmessage = function(e) {
 					offscreenCanvases: [makeCanvas(), makeCanvas()],
 					whiteCanvases: [makeCanvas(), makeCanvas()],
 					compositeCanvas: makeCanvas(),
+					glyphCanvas: makeCanvas(),
 					graphWidth: 150, graphPadding: 20,
 					context: elements.canvas.getContext('2d'),
 					workerResolvers: new Map(),
@@ -1025,13 +1026,14 @@ self.onmessage = function(e) {
 				const height = Math.ceil((bbox.maxY - bbox.minY) * scale) + 4;
 				const drawOffsetX = -Math.min(0, bbox.minX * scale) + 2;
 				if (!Number.isFinite(width) || !Number.isFinite(height) || width <= 0 || height <= 0) return null;
-				const canvas = document.createElement('canvas');
-				canvas.width = width; canvas.height = height;
-				const ctx = canvas.getContext('2d', { willReadFrequently: true });
+				const canvas = this.glyphCanvas;
+				const ctx = prepareCanvas(canvas, width, height);
+				ctx.save();
 				ctx.translate(drawOffsetX, baseline);
 				ctx.scale(1, -1);
 				ctx.fillStyle = '#FFFFFF';
 				glyph.render(ctx, fontSize);
+				ctx.restore();
 				const { data: imageData } = ctx.getImageData(0, 0, width, height);
 				const result = await this.runWorker({
 					buffer: imageData.buffer, width, height, scanYStart: 0, scanYEnd: height, scanXStart: 0, scanXEnd: width

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,15 @@
+We will use **Bolt Mode (Performance)** to address the canvas creation overhead in `getGlyphProfile`.
+
+1. **Diagnosis**:
+   When calculating density or applying autospacing, `getGlyphProfile` is called for each unique glyph. Currently, `getGlyphProfile` allocates a new `<canvas>` element for every glyph using `document.createElement('canvas')`. This causes excessive DOM allocation and garbage collection when analyzing long text strings or fonts with many unique glyphs.
+
+2. **Treatment**:
+   - Add a shared `glyphCanvas` to the class instance properties in the constructor.
+   - Modify `getGlyphProfile` to reuse this `glyphCanvas` by passing it to the existing `prepareCanvas(canvas, width, height)` utility function. `prepareCanvas` handles both resizing and explicitly clearing the context (as required by the system memory).
+
+### Pre-commit steps:
+1. Ensure the Playwright script continues to pass and does not break due to canvas reuse.
+2. Verify visual output isn't compromised (no artifacts left over in glyph profiling).
+
+3. **Metrics/Impact**:
+   Expected to prevent tens to hundreds of canvas instantiations and context allocations per layout pass, noticeably reducing memory pressure and execution time for the `applyAutospacing` logic, especially during initial renders or when typing new characters.

--- a/test_cache.js
+++ b/test_cache.js
@@ -1,0 +1,73 @@
+const { chromium } = require('playwright');
+const path = require('path');
+
+(async () => {
+  const browser = await chromium.launch();
+  const page = await browser.newPage();
+
+  page.on('console', msg => console.log(msg.text()));
+
+  await page.goto(`file://${path.resolve(__dirname, 'OpenDensityTool.html')}`);
+
+  await page.waitForSelector('.group', { state: 'attached' });
+
+  await page.evaluate(async () => {
+    window.workerCalls = 0;
+    const origRunWorker = window.app.runWorker;
+    window.app.runWorker = function(...args) {
+      window.workerCalls++;
+      return origRunWorker.apply(this, args);
+    };
+
+    // We need to load a font to actually use fontkit
+    // For test simplicity, we can fetch a random font from google fonts
+    const resp = await fetch('https://fonts.gstatic.com/s/roboto/v30/KFOmCnqEu92Fr1Mu4mxK.woff2');
+    const blob = await resp.blob();
+    const file = new File([blob], "roboto.woff2", { type: 'font/woff2' });
+
+    const dataTransfer = new DataTransfer();
+    dataTransfer.items.add(file);
+    document.getElementById('file1').files = dataTransfer.files;
+    document.getElementById('file1').dispatchEvent(new Event('change', { bubbles: true }));
+  });
+
+  await page.waitForTimeout(1000); // Wait for font to load
+
+  await page.evaluate(() => {
+    document.getElementById('text1').value = "Typeface";
+    document.getElementById('text1').dispatchEvent(new Event('input'));
+  });
+
+  await page.waitForTimeout(500);
+  await page.evaluate(() => { window.workerCalls = 0; });
+
+  await page.evaluate(() => {
+    document.getElementById('autospacing1').checked = true;
+    document.getElementById('autospacing1').dispatchEvent(new Event('change'));
+  });
+
+  await page.waitForTimeout(1000);
+  let calls = await page.evaluate(() => window.workerCalls);
+  console.log('Worker calls after enabling autospacing:', calls);
+  await page.evaluate(() => { window.workerCalls = 0; });
+
+  await page.evaluate(() => {
+    document.getElementById('tightness1').value = 80;
+    document.getElementById('tightness1').dispatchEvent(new Event('input'));
+  });
+  await page.waitForTimeout(500);
+  calls = await page.evaluate(() => window.workerCalls);
+  console.log('Worker calls after adjusting tightness:', calls);
+  await page.evaluate(() => { window.workerCalls = 0; });
+
+  // And what if we do it again
+  await page.evaluate(() => {
+    document.getElementById('tightness1').value = 90;
+    document.getElementById('tightness1').dispatchEvent(new Event('input'));
+  });
+  await page.waitForTimeout(500);
+  calls = await page.evaluate(() => window.workerCalls);
+  console.log('Worker calls after adjusting tightness again:', calls);
+
+  await browser.close();
+})();


### PR DESCRIPTION
💡 **What:** Added a shared `glyphCanvas` property to `DensityTool` and updated `getGlyphProfile` to reuse it, alongside `ctx.save()` and `ctx.restore()` for safe transform handling.
🎯 **Why:** To eliminate the overhead of repetitive DOM allocation (`document.createElement('canvas')`) during autospacing checks, which negatively impacted the overall performance.
📊 **Impact:** Reduces DOM node creation and context allocations drastically, especially when calculating spacing for new strings. Drops unnecessary memory pressure during optical analysis.
🔬 **Measurement:** You can verify by executing `verify.js` (to assure no regressions) and tracking `Worker` payload dispatches when typing a new query in autospacing mode.

---
*PR created automatically by Jules for task [13626718708142490188](https://jules.google.com/task/13626718708142490188) started by @mahalisyarifuddin*