### PR TITLE
🩺 Medic: Canvas crash on empty string or 0 advance scale

### DIFF
--- a/.jules/codecraft.md
+++ b/.jules/codecraft.md
@@ -27,3 +27,8 @@
 **Mode:** 🩺 Medic
 **Learning:** In `OpenDensityTool.html`, caching keys and internal arrays must be meticulously synced. First, `advanceScale` affected the layout (via tracking unit logic) but wasn't part of the `layoutCache` check, meaning optical spacing failed to recompute when tracking changed. Second, `spacingUnit` was read directly from the DOM inside `generateRenderData` rather than being part of the `inputs` cache key in `getRenderData`, causing unit changes (e.g. % to px) to falsely hit the cache. Finally, the `swap()` method missed `offscreenCanvases` and `whiteCanvases`, which led to cross-contamination of cached canvas contexts after swapping fonts.
 **Action:** 1. Ensure all inputs that alter an operation's output are part of its cache key. 2. When creating centralized input objects for async rendering, read all DOM states upfront. 3. When swapping composite states, explicitly enumerate all parallel internal arrays.
+
+## 2025-10-18 - [Canvas 0-Dimension & NaN Bounds Crashes]
+**Mode:** 🩺 Medic
+**Learning:** During edge cases such as empty strings or `advanceScale` dropping to 0 (e.g., 0% tracking), calculated glyph boundaries and advance widths drop to 0 or produce `NaN` (due to zero-division turning into `Infinity` and then `NaN`). Creating or extracting data from a `canvas` with `width <= 0` or `height <= 0` throws a critical `DOMException` error ("Failed to execute 'drawImage'").
+**Action:** Always provide a minimum non-zero fallback (`width || 1`) for computed canvas dimensions before creating `CanvasRenderingContext2D` contexts, and explicitly intercept execution flows with a safe empty-state return payload whenever valid dimensions or content cannot be established.

--- a/OpenDensityTool.html
+++ b/OpenDensityTool.html
@@ -1287,9 +1287,11 @@ self.onmessage = function(e) {
 				const baseline = Math.ceil(metrics.ascent);
 				const height = Math.ceil(baseline + metrics.descent);
 				if (width > 32767 || height > 32767) throw new Error('Canvas dimensions too large');
+				const safeWidth = width || 1;
+				const safeHeight = height || 1;
 
 				const whiteCanvas = this.whiteCanvases[index];
-				const whiteContext = prepareCanvas(whiteCanvas, width, height);
+				const whiteContext = prepareCanvas(whiteCanvas, safeWidth, safeHeight);
 				whiteContext.save();
 				whiteContext.translate(drawOffsetX, baseline);
 				whiteContext.scale(1, -1);
@@ -1308,22 +1310,22 @@ self.onmessage = function(e) {
 				whiteContext.restore();
 
 				const canvas = this.offscreenCanvases[index];
-				const context = prepareCanvas(canvas, width, height);
+				const context = prepareCanvas(canvas, safeWidth, safeHeight);
 				context.drawImage(whiteCanvas, 0, 0);
 				paint(context, color);
 
 				const scanYStart = Math.max(0, Math.floor(baseline - maxY * scale) - 1);
-				const scanYEnd = Math.min(height, Math.ceil(baseline - minY * scale) + 1);
+				const scanYEnd = Math.min(safeHeight, Math.ceil(baseline - minY * scale) + 1);
 				const scanXStart = Math.max(0, Math.floor(minX * scale + drawOffsetX) - 1);
-				const scanXEnd = Math.min(width, Math.ceil(maxX * scale + drawOffsetX) + 1);
+				const scanXEnd = Math.min(safeWidth, Math.ceil(maxX * scale + drawOffsetX) + 1);
 
 				if (![scanXStart, scanYStart, scanXEnd, scanYEnd].every(Number.isFinite) || scanXEnd <= scanXStart || scanYEnd <= scanYStart) {
-					return { densityByRow: new Float32Array(height), leftProfile: new Int32Array(height).fill(-1), rightProfile: new Int32Array(height).fill(-1), inkPixels: 0, minX: 0, maxX: 0, minY: 0, maxY: 0, maxDensity: 1, graphPath: new Path2D(), ...metrics, drawOffsetX, width, height, canvas, whiteCanvas, baseline, letterSpacing, fontSize: size, font };
+					return { densityByRow: new Float32Array(safeHeight), leftProfile: new Int32Array(safeHeight).fill(-1), rightProfile: new Int32Array(safeHeight).fill(-1), inkPixels: 0, minX: 0, maxX: 0, minY: 0, maxY: 0, maxDensity: 1, graphPath: new Path2D(), ...metrics, drawOffsetX, width: safeWidth, height: safeHeight, canvas, whiteCanvas, baseline, letterSpacing, fontSize: size, font };
 				}
 
 				const { data: imageData } = context.getImageData(scanXStart, scanYStart, scanXEnd - scanXStart, scanYEnd - scanYStart);
 				const analysisData = await this.runWorker({
-					buffer: imageData.buffer, width, height, scanYStart, scanYEnd, scanXStart, scanXEnd
+					buffer: imageData.buffer, width: safeWidth, height: safeHeight, scanYStart, scanYEnd, scanXStart, scanXEnd
 				}, [imageData.buffer]);
 
 				const graphPath = new Path2D();

--- a/verify.js
+++ b/verify.js
@@ -118,3 +118,73 @@ const path = require('path');
 
   await browser.close();
 })();
+// NEW TEST: Empty String Crash (Medic Mode)
+(async () => {
+  const browser = await chromium.launch();
+  const page = await browser.newPage();
+  const filePath = `file://${path.resolve(__dirname, 'OpenDensityTool.html')}`;
+  await page.goto(filePath);
+
+  await page.waitForSelector('.group', { state: 'attached' });
+
+  // upload font first
+  const fileInput = await page.$('#file1');
+  await fileInput.setInputFiles('roboto-regular-webfont.woff');
+  await page.waitForTimeout(500);
+
+  // Clear the text area 1
+  await page.fill('#text1', '');
+
+  // Wait a bit for debounced update
+  await page.waitForTimeout(500);
+
+  // See what is the result
+  const textContent = await page.textContent('#result1');
+  if (textContent.includes('Error')) {
+    console.error('Empty string test failed! Crash observed:', textContent);
+    process.exit(1);
+  }
+
+  console.log('Test passed: empty string does not cause a crash.');
+
+  await browser.close();
+})();
+
+// NEW TEST: AdvanceScale scaling percentage tracking with optical autospacing Crash (Medic Mode)
+(async () => {
+  const browser = await chromium.launch();
+  const page = await browser.newPage();
+  const filePath = `file://${path.resolve(__dirname, 'OpenDensityTool.html')}`;
+  await page.goto(filePath);
+
+  await page.waitForSelector('.group', { state: 'attached' });
+
+  // upload font first
+  const fileInput = await page.$('#file1');
+  await fileInput.setInputFiles('roboto-regular-webfont.woff');
+  await page.waitForTimeout(500);
+
+  // Switch to percent
+  await page.click('#openSettings');
+  await page.selectOption('#spacingUnit', 'percent');
+  await page.click('#closeSettings');
+  await page.waitForTimeout(100);
+
+  // Set tracking to 0%
+  await page.fill('#spacing1', '0');
+
+  // Enable autospacing
+  await page.check('#autospacing1');
+
+  await page.waitForTimeout(500);
+
+  const textContent = await page.textContent('#result1');
+  if (textContent.includes('Error')) {
+    console.error('AdvanceScale test failed! Crash observed:', textContent);
+    process.exit(1);
+  }
+
+  console.log('Test passed: AdvanceScale does not cause a crash.');
+
+  await browser.close();
+})();


### PR DESCRIPTION
# 🩺 Medic: Fix Canvas 0-dimension crash

**Diagnosis**: The application crashes with `DOMException: Failed to execute 'drawImage' on 'CanvasRenderingContext2D'` when users clear the text field completely, or set tracking to 0% with optical spacing enabled. This is because calculating glyph limits produces 0 or NaN, turning the required width and height of canvas instances to zero.
**Location**: `OpenDensityTool.html` inside the `generateRenderData` method around line ~1287 and line ~1318.
**Symptoms**: The frontend interface completely stops rendering or throwing errors in the background when the aforementioned zero values happen.
**Treatment**: Enforced a fallback minimum bounds of 1 dimension (`width || 1` and `height || 1`) for the initialization of offscreen blank and generated canvases, to prevent the `drawImage` native error, and updated `getImageData` to handle these scenarios gracefully. I also appended the discovery to `.jules/codecraft.md`.
**Test**: Augmented the Playwright script `verify.js` to clear the text element and run another to simulate `advanceScale` dropping to 0%. Both tests pass correctly now without exception or errors.

---
*PR created automatically by Jules for task [15432806013540745956](https://jules.google.com/task/15432806013540745956) started by @mahalisyarifuddin*