### PR TITLE
⚡ Bolt: Add Canvas Box density calculation mode

### DIFF
--- a/OpenDensityTool.html
+++ b/OpenDensityTool.html
@@ -582,7 +582,7 @@
 				<div class="controlsSelection">
 					<select id="zoom" aria-label="Zoom level"><option value="fit">Fit to View</option><option value="100">100% Scale</option></select>
 					<select id="render" aria-label="Render mode"><option value="overlay">Overlay</option><option value="side">Side-by-side</option></select>
-					<select id="density" aria-label="Density calculation method"><option value="ink">Ink Box</option><option value="em">Em Box</option></select>
+					<select id="density" aria-label="Density calculation method"><option value="ink">Ink Box</option><option value="em">Em Box</option><option value="canvas">Canvas Box</option></select>
 					<select id="guides" aria-label="Guides"><option value="none">No Guides</option><option value="baseline">Show Baseline</option><option value="metrics">Show Metrics</option></select>
 				</div>
 				<button id="copyImage">Copy Image</button>
@@ -1357,23 +1357,27 @@ self.onmessage = function(e) {
 
 			async update() {
 				const updateId = ++this.updateId;
-				const results = await Promise.all([1, 2].map(async (number, index) => {
+				const baseData = await Promise.all([1,2].map(async(number,index)=>{
 					elements[`dot${number}`].style.backgroundColor = elements[`color${number}`].value;
 					try {
 						const data = await this.getRenderData(index);
-						if (!data) return null;
-						const hasInk = data.maxY >= data.minY;
-						const area = Math.max(1, elements.density.value === 'ink' ? (hasInk ? (data.maxX - data.minX + 1) * (data.maxY - data.minY + 1) : 1) : Math.max(1, data.advanceWidth) * (data.ascent + data.descent));
-						const yMin = hasInk ? Math.round(data.baseline - data.maxY) : 0;
-						const yMax = hasInk ? Math.round(data.baseline - data.minY) : 0;
-						return { ...data, baselineShift: +elements[`shift${number}`].value || 0, density: ((data.inkPixels / area) * 100).toFixed(1), yMin, yMax, inkHeight: hasInk ? (data.maxY - data.minY + 1) : 0 };
-					} catch (error) { return { error: error.message }; }
+						return data?{...data,baselineShift:+elements[`shift${number}`].value||0}:null;
+					} catch(error) { return {error:error.message}; }
 				}));
-
 				if (updateId !== this.updateId) return;
-				this.analyses = results;
+
+				const mode = elements.density.value;
+				const valid = baseData.filter((a,i)=>a&&!a.error&&this.isFontVisible(i));
+				const canvasHeight = Math.ceil(Math.max(0,...valid.map(a=>a.baseline+a.baselineShift))+Math.max(0,...valid.map(a=>a.height-a.baseline-a.baselineShift)));
+
+				this.analyses = baseData.map((data,index)=>(!data||data.error)?data:(()=>{
+					const hasInk = data.maxY>=data.minY;
+					const area = Math.max(1,mode==='ink'?(hasInk?(data.maxX-data.minX+1)*(data.maxY-data.minY+1):1):(mode==='em'?Math.max(1,data.advanceWidth)*(data.ascent+data.descent):Math.max(1,data.advanceWidth)*canvasHeight));
+					return {...data,density:((data.inkPixels/area)*100).toFixed(1),yMin:hasInk?Math.round(data.baseline-data.maxY):0,yMax:hasInk?Math.round(data.baseline-data.minY):0,inkHeight:hasInk?(data.maxY-data.minY+1):0};
+				})());
+
 				this.draw();
-				[1, 2].forEach((number, index) => this.updateResult(number, index));
+				[1,2].forEach((number,index)=>this.updateResult(number,index));
 			}
 
 			draw() {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       playwright:
-        specifier: ^1.60.0
-        version: 1.60.0
+        specifier: ^1.61.1
+        version: 1.61.1
 
 packages:
 
@@ -19,13 +19,13 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
-  playwright-core@1.60.0:
-    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
+  playwright-core@1.61.1:
+    resolution: {integrity: sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==}
     engines: {node: '>=18'}
     hasBin: true
 
-  playwright@1.60.0:
-    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
+  playwright@1.61.1:
+    resolution: {integrity: sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -34,10 +34,10 @@ snapshots:
   fsevents@2.3.2:
     optional: true
 
-  playwright-core@1.60.0: {}
+  playwright-core@1.61.1: {}
 
-  playwright@1.60.0:
+  playwright@1.61.1:
     dependencies:
-      playwright-core: 1.60.0
+      playwright-core: 1.61.1
     optionalDependencies:
       fsevents: 2.3.2

--- a/verify.js
+++ b/verify.js
@@ -188,3 +188,32 @@ const path = require('path');
 
   await browser.close();
 })();
+
+// NEW TEST: Canvas Box Density Mode (Bolt Mode)
+(async () => {
+  const browser = await chromium.launch();
+  const page = await browser.newPage();
+  const filePath = `file://${path.resolve(__dirname, 'OpenDensityTool.html')}`;
+  await page.goto(filePath);
+
+  await page.waitForSelector('.group', { state: 'attached' });
+
+  // upload font first
+  const fileInput = await page.$('#file1');
+  await fileInput.setInputFiles('roboto-regular-webfont.woff');
+  await page.waitForTimeout(500);
+
+  // Change density mode to Canvas Box
+  await page.selectOption('#density', 'canvas');
+  await page.waitForTimeout(500);
+
+  const textContent = await page.textContent('#result1');
+  if (textContent.includes('Error') || !textContent.includes('Density')) {
+    console.error('Canvas Box test failed! Text content:', textContent);
+    process.exit(1);
+  }
+
+  console.log('Test passed: Canvas Box mode works correctly.');
+
+  await browser.close();
+})();


### PR DESCRIPTION
Added a third density calculation mode: "Canvas Box". This mode calculates density based on a shared vertical canvas height derived from the maximum ascent and maximum descent across all visible fonts (including baseline shifts). This provides a way to compare fonts within a common bounding box. Logic was added to `OpenDensityTool.html` and verified with a new test case in `verify.js`.

---
*PR created automatically by Jules for task [665941083843265157](https://jules.google.com/task/665941083843265157) started by @mahalisyarifuddin*