### PR TITLE
🩺 Medic: Fix race condition during async font loading when swapping fonts

### DIFF
--- a/.jules/codecraft.md
+++ b/.jules/codecraft.md
@@ -37,3 +37,8 @@
 **Mode:** 🩺 Medic
 **Learning:** Reusing `canvas` instances and attempting to clear them by re-assigning `canvas.width = dimensions.width` fails to clear the buffer if the new dimensions are strictly equal to the old ones. This causes multiply blending operations to accumulate ink infinitely over successive repaints if the canvas layout does not shift (e.g., when toggling UI elements or swapping identical inputs).
 **Action:** Never rely on dimension assignment (`canvas.width = canvas.width`) to clear a canvas. Always use a helper function (like `prepareCanvas`) that strictly checks dimensions and falls back to `ctx.clearRect(0, 0, width, height)` when the dimensions have not changed.
+
+## 2025-02-27 - [Fix async race condition on swap]
+**Mode:** Medic
+**Learning:** Using index closure variable (`this.loadSequence[index]`) inside `async` code leads to race condition if the arrays are mutated/swapped during execution.
+**Action:** Use unique `Symbol()` assignments for state flags, and resolve the index using `indexOf(symbol)` dynamically when async execution resumes to prevent state desync.

--- a/OpenDensityTool.html
+++ b/OpenDensityTool.html
@@ -712,7 +712,7 @@ self.onmessage = function(e) {
 				const makeCanvas = () => document.createElement('canvas');
 				Object.assign(this, {
 					fonts: [], loadErrors: [], visibility: [true, true], solo: [false, false],
-					loading: [false, false], loadSequence: [0, 0], renderingCache: [],
+					loading: [false, false], loadSequence: [Symbol(), Symbol()], renderingCache: [],
 					profileCache: [new Map(), new Map()],
 					layoutCache: [null, null], analyses: [],
 					offscreenCanvases: [makeCanvas(), makeCanvas()],
@@ -992,7 +992,7 @@ self.onmessage = function(e) {
 			}
 
 			async loadFont(file, index) {
-				const sequence = ++this.loadSequence[index];
+				const sequence = this.loadSequence[index] = Symbol();
 				this.loadErrors[index] = this.fonts[index] = null;
 				this.profileCache[index].clear();
 				this.loading[index] = true;
@@ -1001,14 +1001,17 @@ self.onmessage = function(e) {
 					if (!file) return;
 					if (file.size > 3e7) throw new Error('File too large (max 30MB)');
 					const buffer = await file.arrayBuffer();
-					if (sequence !== this.loadSequence[index]) return;
+					const currentIndex = this.loadSequence.indexOf(sequence);
+					if (currentIndex === -1) return;
 					const font = fontkit.create(new Uint8Array(buffer));
 					if (!font.unitsPerEm) throw new Error('Invalid font');
-					this.fonts[index] = font;
+					this.fonts[currentIndex] = font;
 				} catch (error) {
-					if (sequence === this.loadSequence[index]) this.loadErrors[index] = error.message;
+					const currentIndex = this.loadSequence.indexOf(sequence);
+					if (currentIndex !== -1) this.loadErrors[currentIndex] = error.message;
 				} finally {
-					if (sequence === this.loadSequence[index]) { this.loading[index] = false; this.update(); }
+					const currentIndex = this.loadSequence.indexOf(sequence);
+					if (currentIndex !== -1) { this.loading[currentIndex] = false; this.update(); }
 				}
 			}
 

--- a/verify.js
+++ b/verify.js
@@ -217,3 +217,49 @@ const path = require('path');
 
   await browser.close();
 })();
+
+// NEW TEST: Async Swap Race Condition during File Load (Medic Mode)
+(async () => {
+  const browser = await chromium.launch();
+  const page = await browser.newPage();
+  const filePath = `file://${path.resolve(__dirname, 'OpenDensityTool.html')}`;
+  await page.goto(filePath);
+
+  await page.waitForSelector('.group', { state: 'attached' });
+
+  // Expose a function to trigger file input without awaiting
+  await page.evaluate(() => {
+    window.triggerUploadAndSwap = async () => {
+      // Mock file
+      const blob = new Blob(["dummy"], { type: 'font/woff' });
+      const file = new File([blob], "dummy.woff");
+
+      // Delay arrayBuffer to simulate slow network/large file
+      const origArrayBuffer = file.arrayBuffer.bind(file);
+      file.arrayBuffer = async () => {
+        return new Promise(resolve => {
+          setTimeout(() => resolve(origArrayBuffer()), 500);
+        });
+      };
+
+      app.loadFont(file, 0);
+      app.swap();
+    };
+  });
+
+  await page.evaluate(() => window.triggerUploadAndSwap());
+
+  await page.waitForTimeout(1000);
+
+  const loading = await page.evaluate(() => app.loading);
+  const loadErrors = await page.evaluate(() => app.loadErrors.map(e => !!e));
+
+  if (loading[0] || loading[1] || loadErrors[0] || !loadErrors[1]) {
+    console.error('Async Swap Race Condition test failed! Expected loading: [false, false] and loadErrors: [false, true]', loading, loadErrors);
+    process.exit(1);
+  }
+
+  console.log('Test passed: async swap race condition is handled correctly.');
+
+  await browser.close();
+})();


### PR DESCRIPTION
💡 What: Switched from using static closure `index` in async font load to using unique `Symbol()` assignments and dynamic index lookup `this.loadSequence.indexOf(sequence)`.
🎯 Why: If a user swapped fonts (or performed other actions mutating the array) while a file read or async task was pending, the callback would write back to the stale index.
💥 Symptoms: Result applied to wrong font slot, stuck loading spinners, incorrect error messages.
💉 Treatment: Use dynamic lookup of a tracking Symbol to guarantee the result follows the UI slot if it moves.
🧪 Test: Added Playwright test `test-race2.js` logic to `verify.js` which simulates a delayed font buffer load followed by an immediate swap to guarantee state resolution remains consistent.

---
*PR created automatically by Jules for task [11410266674273061007](https://jules.google.com/task/11410266674273061007) started by @mahalisyarifuddin*